### PR TITLE
Fix for miss-match on maxAge/expiration

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -123,7 +123,7 @@ cookies.forEach(cookie => {
     secure: true
   };
   // Only set expiration if it's a positive integer
-  if (cookie.maxAge > 0) options['max-age'] = cookie.maxAge;
+  if (cookie.expiration > 0) options['max-age'] = cookie.expiration;
   setCookie(name, value, options);
 });
 


### PR DESCRIPTION
The expiration setting doesn't currently work - the property "maxAge" doesn't exist in the cookie object, it is called expiration.