### PR TITLE
Set cookie only if cookie.value exists

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -124,17 +124,19 @@ const cookies = data.cookies.length ? data.cookies : [];
 
 // Go through all the rows in the table and set each as a response cookie
 cookies.forEach(cookie => {
-  const name = cookie.name;
-  const value = cookie.value;
-  const options = {
-    domain: cookie.domain,
-    path: '/',
-    secure: true
-  };
-  // Only set expiration if it's a positive integer
-  if (cookie.expiration > 0) options['max-age'] = cookie.expiration;
-  if (cookie.httpOnly) options.HttpOnly = cookie.httpOnly;
-  setCookie(name, value, options);
+  if (!!cookie.value) {
+    const name = cookie.name;
+    const value = cookie.value;
+    const options = {
+      domain: cookie.domain,
+      path: '/',
+      secure: true
+    };
+    // Only set expiration if it's a positive integer
+    if (cookie.expiration > 0) options['max-age'] = cookie.expiration;
+    if (cookie.httpOnly) options.HttpOnly = cookie.httpOnly;
+    setCookie(name, value, options);
+  }
 });
 
 data.gtmOnSuccess();

--- a/template.tpl
+++ b/template.tpl
@@ -110,6 +110,13 @@ ___TEMPLATE_PARAMETERS___
     "editRowTitle": "Edit Cookie",
     "newRowButtonText": "Add Cookie",
     "newRowTitle": "Add Cookie"
+  },
+  {
+    "type": "CHECKBOX",
+    "name": "noEncode",
+    "checkboxText": "Turn off cookie encoding",
+    "simpleValueType": true,
+    "help": "By default, cookies that are set by this tag are URL encoded (e.g. \u0027this value\u0027 will be turned into \u0027this%20value\u0027). If you want to disable this feature, tick this checkbox."
   }
 ]
 
@@ -135,7 +142,7 @@ cookies.forEach(cookie => {
     // Only set expiration if it's a positive integer
     if (cookie.expiration > 0) options['max-age'] = cookie.expiration;
     if (cookie.httpOnly) options.HttpOnly = cookie.httpOnly;
-    setCookie(name, value, options);
+    setCookie(name, value, options, data.noEncode);
   }
 });
 


### PR DESCRIPTION
Added an additional IF statement that checks if the cookie.value exists. Currently, an empty cookie is set by the tag in the response headers even if the cookie.value is undefined. Maybe I am missing some context here but it looks more convenient to have the tag handle this and skip cookies that would be empty (rather than try to avoid this with triggers).

If I am missing something here, please let me know