### PR TITLE
Add support of noEncode option.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -105,6 +105,16 @@ ___TEMPLATE_PARAMETERS___
           "simpleValueType": true
         },
         "isUnique": false
+      },
+      {
+        "param": {
+          "type": "CHECKBOX",
+          "name": "noEncode",
+          "checkboxText": "Not Encode",
+          "simpleValueType": true,
+          "help": "If checked, the cookie value will not be encoded."
+        },
+        "isUnique": false
       }
     ],
     "editRowTitle": "Edit Cookie",
@@ -134,7 +144,7 @@ cookies.forEach(cookie => {
   // Only set expiration if it's a positive integer
   if (cookie.expiration > 0) options['max-age'] = cookie.expiration;
   if (cookie.httpOnly) options.HttpOnly = cookie.httpOnly;
-  setCookie(name, value, options);
+  setCookie(name, value, options, cookie.noEncode);
 });
 
 data.gtmOnSuccess();


### PR DESCRIPTION
- Add support of noEncode option. https://developers.google.com/tag-manager/serverside/api#setcookie

Example:
I want store "test|done" cookie and read them later. Other system do not provide option to url decode cookie value.
And that's why if cookie value will be encoded I will receive "test%7Cdone" instead "test|done".