### PR TITLE
Added Cookies array exist check

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -119,6 +119,13 @@ ___SANDBOXED_JS_FOR_SERVER___
 // Load template APIs
 const setCookie = require('setCookie');
 
+// Cookies array exist check
+if (!data.cookies) {
+  data.gtmOnSuccess();
+
+  return;
+}
+
 // Create reference to param table
 const cookies = data.cookies.length ? data.cookies : [];
 


### PR DESCRIPTION
The template will fail in case there are no cookies to set provided.
Also, because of this basic test of the template is failing. Usually, templates are rejected in the Template Gallery because of this.